### PR TITLE
Suppress motion detection when large areas appear to change

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,37 +12,49 @@ import (
 )
 
 type Config struct {
-	SPISpeed  int64  `yaml:"spi-speed"`
-	PowerPin  string `yaml:"power-pin"`
-	OutputDir string `yaml:"output-dir"`
-	MinSecs   int    `yaml:"min-secs"`
-	MaxSecs   int    `yaml:"max-secs"`
-	Motion    Motion `yaml:"motion"`
+	SPISpeed  int64        `yaml:"spi-speed"`
+	PowerPin  string       `yaml:"power-pin"`
+	OutputDir string       `yaml:"output-dir"`
+	MinSecs   int          `yaml:"min-secs"`
+	MaxSecs   int          `yaml:"max-secs"`
+	Motion    MotionConfig `yaml:"motion"`
 }
 
-type Motion struct {
-	DeltaThresh uint16 `yaml:"delta-thresh"`
-	CountThresh uint16 `yaml:"count-thresh"`
-	TempThresh  uint16 `yaml:"temp-thresh"`
+type MotionConfig struct {
+	TempThresh        uint16 `yaml:"temp-thresh"`
+	DeltaThresh       uint16 `yaml:"delta-thresh"`
+	CountThresh       int    `yaml:"count-thresh"`
+	NonzeroMaxPercent int    `yaml:"nonzero-max-percent"`
 }
 
 func (conf *Config) Validate() error {
 	if conf.MaxSecs < conf.MinSecs {
 		return errors.New("max-secs should be larger than min-secs")
 	}
+	if err := conf.Motion.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (conf *MotionConfig) Validate() error {
+	if conf.NonzeroMaxPercent < 1 || conf.NonzeroMaxPercent > 100 {
+		return errors.New("nonzero-max-percent should be in range 1 - 100")
+	}
 	return nil
 }
 
 var defaultConfig = Config{
-	SPISpeed:  30000000,
+	SPISpeed:  25000000,
 	PowerPin:  "GPIO23",
 	OutputDir: "/var/spool/cptv",
 	MinSecs:   10,
 	MaxSecs:   600,
-	Motion: Motion{
-		DeltaThresh: 20,
-		CountThresh: 10,
-		TempThresh:  3200,
+	Motion: MotionConfig{
+		TempThresh:        3000,
+		DeltaThresh:       30,
+		CountThresh:       5,
+		NonzeroMaxPercent: 50,
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func runMain() error {
 			if _, isNextFrameErr := err.(*nextFrameErr); !isNextFrameErr {
 				return err
 			}
+			log.Printf("recording error: %v", err)
 		}
 		log.Println("closing camera")
 		camera.Close()
@@ -101,11 +102,7 @@ func runMain() error {
 }
 
 func runRecordings(conf *Config, camera *lepton3.Lepton3) error {
-	motion := NewMotionDetector(
-		conf.Motion.DeltaThresh,
-		conf.Motion.CountThresh,
-		conf.Motion.TempThresh,
-	)
+	motion := NewMotionDetector(conf.Motion)
 
 	prevFrame := new(lepton3.Frame)
 	frame := new(lepton3.Frame)


### PR DESCRIPTION
Motion detection is now suppressed when a configurable percentage of the frame (default is 50%) appears to have movement. This is deal with sudden jumps in the readings as the camera recalibrates due to rapid temperature change. This phenonmenon was causing numerous false positives.

Also:
- set better motion detection defaults (based on analysis of real world footage)
- set more sensisble default SPI speed
- log errors from NextFrame
- pass the Config.Motion struct straight into the motion detector constructor