### PR TITLE
Automatically record to USB drive when present

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,8 @@ nfpm:
   files:
     "thermal-recorder.service": "/etc/systemd/system/thermal-recorder.service"
     "leptond.service": "/etc/systemd/system/leptond.service"
+    "set-thermal-recorder-output/set-thermal-recorder-output.service": "/etc/systemd/system/set-thermal-recorder-output.service"
+    "set-thermal-recorder-output/set-thermal-recorder-output": "/usr/bin/set-thermal-recorder-output"
 
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'

--- a/set-thermal-recorder-output/set-thermal-recorder-output
+++ b/set-thermal-recorder-output/set-thermal-recorder-output
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+
+import glob
+import os
+import shutil
+import sys
+from os import path
+
+USAGE = """\
+usage: set-thermal-recorder-output <mode> [args...]
+
+where mode is one of:
+
+   mount <mount point>
+   umount
+"""
+
+DEFAULT_OUTPUT = '/var/spool/cptv'
+
+
+def main():
+    mode = arg(0)
+
+    if mode == "mount":
+        handle_mount(arg(1))
+    elif mode == "umount":
+        handle_umount()
+    else:
+        usage()
+
+
+def arg(index):
+    try:
+        return sys.argv[index + 1]
+    except IndexError:
+        usage()
+
+
+def usage():
+    print(USAGE)
+    sys.exit(1)
+
+
+def handle_mount(mount_point):
+    set_output_dir(mount_point)
+    kill_recorder()
+    move_cptv_files(DEFAULT_OUTPUT, mount_point)
+
+
+def handle_umount():
+    set_output_dir(DEFAULT_OUTPUT)
+    kill_recorder()
+
+
+def set_output_dir(directory):
+    print('setting output to "{}"'.format(directory))
+
+    out_line = 'output-dir: "{}"\n'.format(directory)
+    lines = []
+    updated = False
+    with open("/etc/thermal-recorder.yaml") as f:
+        for line in f:
+            if line.startswith('output-dir:'):
+                lines.append(out_line)
+                updated = True
+            else:
+                lines.append(line)
+
+    if not updated:
+        lines.append(out_line)
+
+    with open("/etc/thermal-recorder.yaml", "wt") as f:
+        f.write(''.join(lines))
+
+
+def kill_recorder():
+    os.system('pkill -f bin/thermal-recorder')
+
+
+def move_cptv_files(src_dir, dst_dir):
+    for filename in glob.glob(path.join(src_dir, '*.cptv')):
+        shutil.move(filename, dst_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/set-thermal-recorder-output/set-thermal-recorder-output
+++ b/set-thermal-recorder-output/set-thermal-recorder-output
@@ -78,8 +78,10 @@ def kill_recorder():
 
 
 def move_cptv_files(src_dir, dst_dir):
+    print("moving CPTV files to external drive")
     for filename in glob.glob(path.join(src_dir, '*.cptv')):
         shutil.move(filename, dst_dir)
+    print("done moving CPTV files to external drive")
 
 
 if __name__ == '__main__':

--- a/set-thermal-recorder-output/set-thermal-recorder-output.service
+++ b/set-thermal-recorder-output/set-thermal-recorder-output.service
@@ -7,8 +7,8 @@ DefaultDependencies=no
 Type=simple
 Restart=no
 RemainAfterExit=true
-ExecStart=/home/pi/set-thermal-recorder-output mount /media/cp
-ExecStop=/home/pi/set-thermal-recorder-output umount
+ExecStart=/usr/bin/set-thermal-recorder-output mount /media/cp
+ExecStop=/usr/bin/set-thermal-recorder-output umount
 
 [Install]
 WantedBy=media-cp.mount

--- a/set-thermal-recorder-output/set-thermal-recorder-output.service
+++ b/set-thermal-recorder-output/set-thermal-recorder-output.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Adjust thermal-recorder to use USB drive if present
+RequiresMountsFor=/media/cp
+DefaultDependencies=no
+
+[Service]
+Type=simple
+Restart=no
+RemainAfterExit=true
+ExecStart=/home/pi/set-thermal-recorder-output mount /media/cp
+ExecStop=/home/pi/set-thermal-recorder-output umount
+
+[Install]
+WantedBy=media-cp.mount

--- a/thermal-recorder.service
+++ b/thermal-recorder.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/thermal-recorder
-Restart=on-failure
+Restart=always
 RestartSec=3s
 
 [Install]


### PR DESCRIPTION
If a volume labelled "cp" is mounted, the set-thermal-recorder-output
service is started. This reconfigures thermal-recorder to use the
external volume and restarts it. Any CPTV files in /var/spool/CPTV are
also moved to the volume.

When/if the drive is removed, thermal-recorder is reconfigured to
write to /var/spool/CPTV again.