### PR TITLE
Update go-cptv dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/TheCacophonyProject/go-cptv"
   packages = ["."]
-  revision = "b4d729fdf16ecafb016b9d9151fff8fbe10a6e5b"
+  revision = "c20b943db215789bbfddbea1e7a2a08f128b94e7"
 
 [[projects]]
   branch = "master"
@@ -51,7 +51,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
@@ -76,7 +79,35 @@
 [[projects]]
   branch = "v2"
   name = "periph.io/x/periph"
-  packages = [".","conn","conn/gpio","conn/gpio/gpioreg","conn/i2c","conn/i2c/i2creg","conn/mmr","conn/pin","conn/pin/pinreg","conn/spi","conn/spi/spireg","devices","devices/lepton/cci","devices/lepton/internal","host","host/allwinner","host/bcm283x","host/chip","host/cpu","host/distro","host/fs","host/odroidc1","host/pine64","host/pmem","host/rpi","host/sysfs","host/videocore"]
+  packages = [
+    ".",
+    "conn",
+    "conn/gpio",
+    "conn/gpio/gpioreg",
+    "conn/i2c",
+    "conn/i2c/i2creg",
+    "conn/mmr",
+    "conn/pin",
+    "conn/pin/pinreg",
+    "conn/spi",
+    "conn/spi/spireg",
+    "devices",
+    "devices/lepton/cci",
+    "devices/lepton/internal",
+    "host",
+    "host/allwinner",
+    "host/bcm283x",
+    "host/chip",
+    "host/cpu",
+    "host/distro",
+    "host/fs",
+    "host/odroidc1",
+    "host/pine64",
+    "host/pmem",
+    "host/rpi",
+    "host/sysfs",
+    "host/videocore"
+  ]
   revision = "d06ef89e37e829cc301f5babee628e6c6e36d7c5"
   source = "https://github.com/TheCacophonyProject/periph.git"
 

--- a/cmd/thermal-recorder/main.go
+++ b/cmd/thermal-recorder/main.go
@@ -142,7 +142,6 @@ func handleConn(conn net.Conn, conf *Config, turret *TurretController, recording
 	frameLoop := NewFrameLoop(loopFrames)
 
 	frame := frameLoop.Current()
-	var zeroFrame lepton3.Frame
 
 	var writer *cptv.FileWriter
 	defer func() {
@@ -207,7 +206,7 @@ func handleConn(conn net.Conn, conf *Config, turret *TurretController, recording
 				return err
 			}
 
-			if err = writeInitialFramesToFile(writer, frameLoop.GetHistory(), &zeroFrame); err != nil {
+			if err = writeInitialFramesToFile(writer, frameLoop.GetHistory()); err != nil {
 				return err
 			}
 
@@ -228,7 +227,7 @@ func handleConn(conn net.Conn, conf *Config, turret *TurretController, recording
 
 		// If recording, write the frame.
 		if writer != nil {
-			err := writer.WriteFrame(frameLoop.Previous(), frame)
+			err := writer.WriteFrame(frame)
 			if err != nil {
 				return err
 			}
@@ -305,19 +304,17 @@ func checkDiskSpace(mb uint64, dir string) (bool, error) {
 	return fs.Bavail*uint64(fs.Bsize)/1024/1024 >= mb, nil
 }
 
-func writeInitialFramesToFile(writer *cptv.FileWriter, frames []*lepton3.Frame, firstFrame *lepton3.Frame) error {
-	prevFrame := firstFrame
+func writeInitialFramesToFile(writer *cptv.FileWriter, frames []*lepton3.Frame) error {
 	var frame *lepton3.Frame
 	ii := 0
 
 	// it never writes the current frame as this will be written as part of the program!!
 	for ii < len(frames)-1 {
 		frame = frames[ii]
-		if err := writer.WriteFrame(prevFrame, frame); err != nil {
+		if err := writer.WriteFrame(frame); err != nil {
 			return err
 		}
 		ii++
-		prevFrame = frame
 	}
 
 	return nil

--- a/vendor/github.com/TheCacophonyProject/go-cptv/.travis.yml
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - "1.9.x"
+  - "1.10.x"
+
+script:
+  - go vet && go test

--- a/vendor/github.com/TheCacophonyProject/go-cptv/Gopkg.lock
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/Gopkg.lock
@@ -21,9 +21,12 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  packages = [
+    "assert",
+    "require"
+  ]
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -40,13 +43,25 @@
 [[projects]]
   branch = "v2"
   name = "periph.io/x/periph"
-  packages = ["conn","conn/gpio","conn/i2c","conn/i2c/i2creg","conn/mmr","conn/pin","conn/spi","conn/spi/spireg","devices","devices/lepton/cci","devices/lepton/internal"]
+  packages = [
+    "conn",
+    "conn/gpio",
+    "conn/i2c",
+    "conn/i2c/i2creg",
+    "conn/mmr",
+    "conn/pin",
+    "conn/spi",
+    "conn/spi/spireg",
+    "devices",
+    "devices/lepton/cci",
+    "devices/lepton/internal"
+  ]
   revision = "a5370d2227a0b687c67b5e751eef053908b20f59"
   source = "https://github.com/TheCacophonyProject/periph.git"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "317923ff3ea3205763e88fef238eb0eac137c2f9f8f4756afeaa874a035f65b4"
+  inputs-digest = "c5a0979833b08c2b4de9758dad26942b147c9e7f4bcbf749cc2950f5e805d8d1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/TheCacophonyProject/go-cptv/Gopkg.toml
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/Gopkg.toml
@@ -7,4 +7,4 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.1.4"
+  version = "1.2.1"

--- a/vendor/github.com/TheCacophonyProject/go-cptv/README.md
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/README.md
@@ -1,0 +1,79 @@
+# go-cptv
+
+[![Build Status](https://api.travis-ci.com/TheCacophonyProject/go-cptv.svg?branch=master)](https://travis-ci.com/TheCacophonyProject/go-cptv)
+
+This package implements a Go package for generating and consuming
+Cacophony Project Thermal Video (CPTV) files. For more details on
+these files see the [specification](https://github.com/TheCacophonyProject/go-cptv/blob/master/SPEC.md).
+
+
+## Example Usage
+
+### Writing CPTV Files
+
+```go
+
+import (
+    "github.com/TheCacophonyProject/go-cptv"
+    "github.com/TheCacophonyProject/lepton3"
+)
+
+
+func writeFrames(frames []*lepton3.Frame) error {
+    w := cptv.NewFileWriter("out.cptv")
+    defer w.Close()
+    err := w.WriterHeader("device-name")
+    if err != nil {
+        return err
+    }
+    for _, frame := range frames {
+        err := w.WriteFrame(frame)
+        if err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+### Reading CPTV Files
+
+```go
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/TheCacophonyProject/go-cptv"
+    "github.com/TheCacophonyProject/lepton3"
+)
+
+
+func readFrames() ([]*lepton3.Frame, error) {
+    f, err := os.Open("some.cptv")
+    if err != nil {
+        return nil, err
+    }
+    defer f.Close()
+
+    r, err := cptv.NewReader(f)
+    if err != nil {
+        return nil, err
+    }
+    fmt.Println("timestamp:", r.Timestamp())
+    fmt.Println("device:", r.DeviceName())
+
+    var out []*lepton3.Frame
+    for {
+        frame := new(lepton3.Frame)
+        err := r.ReadFrame(frame)
+        if err != nil {
+            if err == io.EOF {
+                return out, nil
+            }
+            return err
+        }
+        out = append(out, frame)
+    }
+}
+```

--- a/vendor/github.com/TheCacophonyProject/go-cptv/builder.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/builder.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cptv
 
 import (
@@ -53,5 +67,8 @@ func (b *Builder) WriteFrame(f *FieldWriter, frameData []byte) error {
 }
 
 func (b *Builder) Close() error {
+	if err := b.w.Flush(); err != nil {
+		return err
+	}
 	return b.w.Close()
 }

--- a/vendor/github.com/TheCacophonyProject/go-cptv/compress.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/compress.go
@@ -1,7 +1,18 @@
-package cptv
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// XXX docs!
-// XXX tests!
+package cptv
 
 import (
 	"bytes"
@@ -12,39 +23,54 @@ import (
 	"github.com/TheCacophonyProject/lepton3"
 )
 
+// NewCompressor creates a new Compressor.
+func NewCompressor() *Compressor {
+	elems := lepton3.FrameRows * lepton3.FrameCols
+	outBuf := new(bytes.Buffer)
+	outBuf.Grow(2 * elems) // 16 bits per element; worst case
+	return &Compressor{
+		rows:       lepton3.FrameRows,
+		cols:       lepton3.FrameCols,
+		frameDelta: make([]int32, elems),
+		adjDeltas:  make([]int32, elems-1),
+		outBuf:     outBuf,
+		prevFrame:  new(lepton3.Frame),
+	}
+}
+
+// Compressor generates a compressed representation of successive
+// lepton3 Frames, returning CPTV frames.
 type Compressor struct {
 	cols, rows int
 	frameDelta []int32
 	adjDeltas  []int32
 	outBuf     *bytes.Buffer
+	prevFrame  *lepton3.Frame
 }
 
-func NewCompressor(cols, rows int) *Compressor {
-	elems := rows * cols
-	outBuf := new(bytes.Buffer)
-	outBuf.Grow(2 * elems) // 16 bits per element; worst case
-	return &Compressor{
-		rows:       rows,
-		cols:       cols,
-		frameDelta: make([]int32, elems),
-		adjDeltas:  make([]int32, (elems)-1),
-		outBuf:     outBuf,
-	}
-}
-
-func (c *Compressor) Next(prev, curr *lepton3.Frame) (uint8, []byte) {
+// Next takes the next lepton3.Frame in a recording and converts it to
+// a compressed stream of bytes. The bit width used for packing is
+// also returned (this is required for unpacking).
+//
+// IMPORTANT: The returned byte slice is reused and therefore is only
+// valid until the next call to Next.
+func (c *Compressor) Next(curr *lepton3.Frame) (uint8, []byte) {
 	// Generate the interframe delta.
 	// The output is written in a "snaked" fashion to avoid
 	// potentially greater deltas at the edges in the next stage.
 	var i int
 	for y := 0; y < c.rows; y++ {
 		i = y * c.cols
-		if y%2 == 1 {
+		if y&1 == 1 {
 			i += c.cols - 1
 		}
 		for x := 0; x < c.cols; x++ {
-			c.frameDelta[i] = int32(curr[y][x]) - int32(prev[y][x])
-			if y%2 == 0 {
+			c.frameDelta[i] = int32(curr[y][x]) - int32(c.prevFrame[y][x])
+			// Now that prevFrame[y][x] has been used, copy the value
+			// for the current frame in for the next call to Next().
+			// TODO: it might be fast to copy() rows separately.
+			c.prevFrame[y][x] = curr[y][x]
+			if y&1 == 0 {
 				i++
 			} else {
 				i--
@@ -74,6 +100,71 @@ func (c *Compressor) Next(prev, curr *lepton3.Frame) (uint8, []byte) {
 	return width, c.outBuf.Bytes()
 }
 
+// NewDecompressor creates a new Decompressor.
+func NewDecompressor() *Decompressor {
+	return &Decompressor{
+		rows:       lepton3.FrameRows,
+		cols:       lepton3.FrameCols,
+		pixelCount: lepton3.FrameRows * lepton3.FrameCols,
+		prevFrame:  new(lepton3.Frame),
+	}
+}
+
+// Decompressor is used to decompress successive CPTV frames. See the
+// Next() method.
+type Decompressor struct {
+	cols, rows, pixelCount int
+	prevFrame              *lepton3.Frame
+	deltas                 [lepton3.FrameRows][lepton3.FrameCols]int32
+}
+
+// ByteReaderReader combines io.Reader and io.ByteReader.
+type ByteReaderReader interface {
+	io.Reader
+	io.ByteReader
+}
+
+// Next reads of stream of bytes as a ByteReaderReader and
+// decompresses them using the bit width provided into the
+// lepton3.Frame provided.
+func (d *Decompressor) Next(bitWidth uint8, compressed ByteReaderReader, out *lepton3.Frame) error {
+	var v int32
+	err := binary.Read(compressed, binary.LittleEndian, &v)
+	if err != nil {
+		return err
+	}
+
+	unpacker := NewBitUnpacker(bitWidth, compressed)
+	d.deltas[0][0] = v
+	for i := 1; i < d.pixelCount; i++ {
+		y := i / lepton3.FrameCols
+		x := i % lepton3.FrameCols
+		// Deltas are "snaked" so work backwards through every second row.
+		if y&1 == 1 {
+			x = lepton3.FrameCols - x - 1
+		}
+
+		dv, err := unpacker.Next()
+		if err != nil {
+			return err
+		}
+		v += dv
+		d.deltas[y][x] = v
+	}
+
+	// Add to delta frame to previous frame.
+	for y := 0; y < lepton3.FrameRows; y++ {
+		for x := 0; x < lepton3.FrameCols; x++ {
+			out[y][x] = uint16(int32(d.prevFrame[y][x]) + d.deltas[y][x])
+			// Now that prevFrame[y][x] has been used, copy the new
+			// value in for the next call to Next() to use.
+			// TODO: it might be fast to copy() rows separately.
+			d.prevFrame[y][x] = out[y][x]
+		}
+	}
+	return nil
+}
+
 // PackBits takes a slice of signed integers and packs them into an
 // abitrary (smaller) bit width. The most significant bit is written
 // out first.
@@ -81,7 +172,7 @@ func PackBits(width uint8, input []int32, w io.ByteWriter) {
 	var bits uint32 // scratch buffer
 	var nBits uint8 // number of bits in use in scratch
 	for _, d := range input {
-		bits |= twosComp(d, width) << (32 - width - nBits)
+		bits |= uint32(twosComp(d, width) << (32 - width - nBits))
 		nBits += width
 		for nBits >= 8 {
 			w.WriteByte(uint8(bits >> 24))
@@ -92,6 +183,42 @@ func PackBits(width uint8, input []int32, w io.ByteWriter) {
 	if nBits > 0 {
 		w.WriteByte(uint8(bits >> 24))
 	}
+}
+
+// NewBitUnpacker creates a new BitUnpacker. Integers will be
+// extracted from the ByteReader and are expected to be packed at the
+// bit width specified.
+func NewBitUnpacker(width uint8, r io.ByteReader) *BitUnpacker {
+	return &BitUnpacker{
+		bitw: width,
+		r:    r,
+	}
+}
+
+// BitUnpacker extracts signed integers, packed at some bit width,
+// from a bitstream.
+type BitUnpacker struct {
+	r     io.ByteReader
+	bitw  uint8
+	bits  uint32
+	nbits uint8
+}
+
+// Next returns the next signed integer from the bitstream.
+func (u *BitUnpacker) Next() (int32, error) {
+	for u.nbits < u.bitw {
+		b, err := u.r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		u.bits |= uint32(b) << uint8(24-u.nbits)
+		u.nbits += 8
+	}
+
+	out := twosUncomp(u.bits>>(32-u.bitw), u.bitw)
+	u.bits = u.bits << u.bitw
+	u.nbits -= u.bitw
+	return out, nil
 }
 
 func abs(x int32) uint32 {
@@ -105,8 +232,14 @@ func twosComp(v int32, width uint8) uint32 {
 	if v >= 0 {
 		return uint32(v)
 	}
-	widthMask := uint32((1 << width) - 1) // all 1's for the target width
-	return uint32(-(v+1))&widthMask ^ widthMask
+	return (^uint32(-v) + 1) & uint32((1<<width)-1)
+}
+
+func twosUncomp(v uint32, width uint8) int32 {
+	if v&(1<<(width-1)) == 0 {
+		return int32(v) // positive
+	}
+	return -int32((^v + 1) & uint32((1<<width)-1))
 }
 
 func numBits(x uint32) uint8 {

--- a/vendor/github.com/TheCacophonyProject/go-cptv/compress_test.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/compress_test.go
@@ -1,10 +1,58 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cptv
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/TheCacophonyProject/lepton3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCompressDecompress(t *testing.T) {
+	frame0 := makeTestFrame()
+	frame1 := makeOffsetFrame(frame0)
+
+	// Compress the frames.
+	compressor := NewCompressor()
+	bitWidth0, frameComp := compressor.Next(frame0)
+	// first frame has no compression
+	assert.Equal(t, uint8(14), bitWidth0)
+	assert.Equal(t, 33603, len(frameComp))
+	frame0Comp := make([]byte, len(frameComp))
+	copy(frame0Comp, frameComp)
+
+	bitWidth1, frame1Comp := compressor.Next(frame1)
+	assert.Equal(t, uint8(2), bitWidth1)
+	assert.Equal(t, 4804, len(frame1Comp))
+
+	// Decompress the frames and confirm the output is the same as the original.
+	decompressor := NewDecompressor()
+
+	frame0d := new(lepton3.Frame)
+	err := decompressor.Next(bitWidth0, bytes.NewReader(frame0Comp), frame0d)
+	require.NoError(t, err)
+	assert.Equal(t, frame0, frame0d)
+
+	frame1d := new(lepton3.Frame)
+	err = decompressor.Next(bitWidth1, bytes.NewReader(frame1Comp), frame1d)
+	require.NoError(t, err)
+	assert.Equal(t, frame1, frame1d)
+}
 
 func TestTwosComp(t *testing.T) {
 	tests := []struct {
@@ -12,6 +60,9 @@ func TestTwosComp(t *testing.T) {
 		width    uint8
 		expected uint32
 	}{
+
+		{-1, 4, 15},
+
 		// Width 8
 		{0, 8, 0},
 		{1, 8, 1},
@@ -43,11 +94,33 @@ func TestTwosComp(t *testing.T) {
 	}
 
 	for _, x := range tests {
-		assert.Equal(
-			t,
-			x.expected,
-			twosComp(x.input, x.width),
-			"%d (width=%d)", x.input, x.width,
-		)
+		twos := twosComp(x.input, x.width)
+		assert.Equal(t, x.expected, twos, "twosComp(%d, %d)", x.input, x.width)
+
+		untwos := twosUncomp(twos, x.width)
+		assert.Equal(t, x.input, untwos, "twosUncomp(%d, %d)", twos, x.width)
 	}
+}
+
+func makeTestFrame() *lepton3.Frame {
+	// Generate a frame with values between 1024 and 8196
+	out := new(lepton3.Frame)
+	const minVal = 1024
+	const maxVal = 8196
+	for y := 0; y < lepton3.FrameRows; y++ {
+		for x := 0; x < lepton3.FrameCols; x++ {
+			out[y][x] = uint16(((y * x) % (maxVal - minVal)) + minVal)
+		}
+	}
+	return out
+}
+
+func makeOffsetFrame(in *lepton3.Frame) *lepton3.Frame {
+	out := new(lepton3.Frame)
+	for y := 0; y < lepton3.FrameRows; y++ {
+		for x := 0; x < lepton3.FrameCols; x++ {
+			out[y][x] = in[y][x] + uint16(x)
+		}
+	}
+	return out
 }

--- a/vendor/github.com/TheCacophonyProject/go-cptv/cptvtool/main.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/cptvtool/main.go
@@ -1,12 +1,26 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package main
+
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/TheCacophonyProject/go-cptv"
+	"github.com/TheCacophonyProject/lepton3"
 )
 
 func main() {
@@ -21,37 +35,36 @@ func runMain() error {
 	if len(os.Args) != 2 {
 		return fmt.Errorf("usage: %s <filename>", os.Args[0])
 	}
-	file, err := os.Open(os.Args[1])
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	bfile := bufio.NewReader(file)
-	r, err := cptv.NewParser(bfile)
-	if err != nil {
-		return err
-	}
-	fields, err := r.Header()
-	if err != nil {
-		return err
-	}
 
-	fmt.Println(fields.Timestamp(cptv.Timestamp))
-	fmt.Println(fields.Uint32(cptv.XResolution))
-	fmt.Println(fields.Uint32(cptv.YResolution))
-	fmt.Println(fields.Uint8(cptv.Compression))
-	fmt.Println(fields.String(cptv.DeviceName))
+	fr, err := cptv.NewFileReader(os.Args[1])
+	if err != nil {
+		return err
+	}
+	defer fr.Close()
 
+	fmt.Println("Timestamp:   ", fr.Timestamp())
+	fmt.Println("Device Name: ", fr.DeviceName())
+
+	// Read the frames and get a frame count. This is an illustration of
+	// frame reading - the r.FrameCount method will do the same thing (and
+	// will similarly leave the file pointer at EOF)
 	frames := 0
+	frame := new(lepton3.Frame)
 	for {
-		_, _, err := r.Frame()
-		if err == io.EOF {
-			break
-		} else if err != nil {
+		err := fr.ReadFrame(frame)
+		if err != nil {
+			if err == io.EOF {
+				fmt.Print(".")
+				frames++ // the last valid read returns EOF
+				break
+			}
 			return err
 		}
 		frames++
+		fmt.Print(".")
 	}
-	fmt.Println("frames:", frames)
+	fmt.Print("\n")
+	fmt.Println("Frame Count: ", frames)
+
 	return nil
 }

--- a/vendor/github.com/TheCacophonyProject/go-cptv/fields.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/fields.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cptv
 
 import (
@@ -107,7 +121,6 @@ func NewFieldWriter() *FieldWriter {
 }
 
 // FieldWriter generates CPTV encoded fields.
-// XXX: merge with Fields
 type FieldWriter struct {
 	data       []byte
 	fieldCount uint8
@@ -144,7 +157,6 @@ func (f *FieldWriter) Timestamp(code byte, t time.Time) {
 }
 
 func (f *FieldWriter) String(code byte, v string) error {
-
 	if len(v) > 255 {
 		return fmt.Errorf("String length %d greater than 255.", len(v))
 	}

--- a/vendor/github.com/TheCacophonyProject/go-cptv/filereader.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/filereader.go
@@ -19,33 +19,39 @@ import (
 	"os"
 )
 
-func NewFileWriter(filename string) (*FileWriter, error) {
-	f, err := os.Create(filename)
+// NewFileReader returns a new FileReader from the filename.
+func NewFileReader(filename string) (*FileReader, error) {
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
-	bw := bufio.NewWriter(f)
-	return &FileWriter{
-		Writer: NewWriter(bw),
-		bw:     bw,
+	br := bufio.NewReader(f)
+	r, err := NewReader(br)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &FileReader{
+		Reader: r,
+		br:     br,
 		f:      f,
 	}, nil
 }
 
-// FileWriter wraps a Writer and provides a convenient way of writing
-// a CPTV stream to a disk file.
-type FileWriter struct {
-	*Writer
-	bw *bufio.Writer
+// FileReader wraps a Reader and provides a convenient way of reading
+// a CPTV stream from a disk file.
+type FileReader struct {
+	*Reader
+	br *bufio.Reader
 	f  *os.File
 }
 
-func (fw *FileWriter) Name() string {
-	return fw.f.Name()
+// Name returns the name of the FileReader
+func (fr *FileReader) Name() string {
+	return fr.f.Name()
 }
 
-func (fw *FileWriter) Close() {
-	fw.Writer.Close()
-	fw.bw.Flush()
-	fw.f.Close()
+// Close closes the file
+func (fr *FileReader) Close() {
+	fr.f.Close()
 }

--- a/vendor/github.com/TheCacophonyProject/go-cptv/nreader.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/nreader.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cptv
 
 import (

--- a/vendor/github.com/TheCacophonyProject/go-cptv/reader.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/reader.go
@@ -1,0 +1,96 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cptv
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/TheCacophonyProject/lepton3"
+)
+
+// NewReader returns a new Reader from the io.Reader given.
+func NewReader(r io.Reader) (*Reader, error) {
+	parser, err := NewParser(bufio.NewReader(r))
+	if err != nil {
+		return nil, err
+	}
+	header, err := parser.Header()
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{
+		parser: parser,
+		decomp: NewDecompressor(),
+		header: header,
+	}, nil
+}
+
+// Reader uses a Parser and Decompressor to read CPTV recordings.
+type Reader struct {
+	parser *Parser
+	decomp *Decompressor
+	header Fields
+}
+
+// Timestamp returns the CPTV timestamp. A zero time is returned if
+// the field wasn't present (shouldn't happen).
+func (r *Reader) Timestamp() time.Time {
+	ts, _ := r.header.Timestamp(Timestamp)
+	return ts
+}
+
+// DeviceName returns the device name field from the CPTV
+// recording. Returns an empty string if the device name field wasn't
+// present.
+func (r *Reader) DeviceName() string {
+	name, _ := r.header.String(DeviceName)
+	return name
+}
+
+// ReadFrame extracts and decompresses the next frame in a CPTV
+// recording. At the end of the recording an io.EOF error will be
+// returned.
+func (r *Reader) ReadFrame(out *lepton3.Frame) error {
+	fields, frameReader, err := r.parser.Frame()
+	if err != nil {
+		return err
+	}
+	bitWidth, err := fields.Uint8(BitWidth)
+	if err != nil {
+		return err
+	}
+	return r.decomp.Next(bitWidth, &nReader{frameReader}, out)
+}
+
+// FrameCount returns the remaining number of frames in a CPTV file.
+// After this call, all remaining frames will have been consumed.
+func (r *Reader) FrameCount() (int, error) {
+	count := 0
+	for {
+		_, fr, err := r.parser.Frame()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return count, err
+		}
+		io.Copy(ioutil.Discard, fr)
+		count++
+	}
+	return count, nil
+}

--- a/vendor/github.com/TheCacophonyProject/go-cptv/reader_frame_count_test.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/reader_frame_count_test.go
@@ -14,22 +14,28 @@
 
 package cptv
 
-const (
-	magic        = "CPTV"
-	version byte = 0x01
+import (
+	"bytes"
+	"testing"
 
-	headerSection = 'H'
-	frameSection  = 'F'
-
-	// Header field keys
-	Timestamp   byte = 'T'
-	XResolution byte = 'X'
-	YResolution byte = 'Y'
-	Compression byte = 'C'
-	DeviceName  byte = 'D'
-
-	// Frame field keys
-	Offset    byte = 't'
-	BitWidth  byte = 'w'
-	FrameSize byte = 'f'
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestReaderFrameCount(t *testing.T) {
+	frame := makeTestFrame()
+	cptvBytes := new(bytes.Buffer)
+
+	w := NewWriter(cptvBytes)
+	require.NoError(t, w.WriteHeader("nz43"))
+	require.NoError(t, w.WriteFrame(frame))
+	require.NoError(t, w.WriteFrame(frame))
+	require.NoError(t, w.WriteFrame(frame))
+	require.NoError(t, w.Close())
+
+	r, err := NewReader(cptvBytes)
+	require.NoError(t, err)
+	c, err := r.FrameCount()
+	require.NoError(t, err)
+	assert.Equal(t, 3, c)
+}

--- a/vendor/github.com/TheCacophonyProject/go-cptv/writer.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/writer.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cptv
 
 import (
@@ -10,7 +24,7 @@ import (
 func NewWriter(w io.Writer) *Writer {
 	return &Writer{
 		bldr: NewBuilder(w),
-		comp: NewCompressor(lepton3.FrameCols, lepton3.FrameRows),
+		comp: NewCompressor(),
 	}
 }
 
@@ -40,9 +54,9 @@ func (w *Writer) WriteHeader(deviceName string) error {
 	return w.bldr.WriteHeader(fields)
 }
 
-func (w *Writer) WriteFrame(prevFrame, frame *lepton3.Frame) error {
+func (w *Writer) WriteFrame(frame *lepton3.Frame) error {
 	dt := uint64(time.Since(w.t0))
-	bitWidth, compFrame := w.comp.Next(prevFrame, frame)
+	bitWidth, compFrame := w.comp.Next(frame)
 	fields := NewFieldWriter()
 	fields.Uint32(Offset, uint32(dt/1000))
 	fields.Uint8(BitWidth, uint8(bitWidth))

--- a/vendor/github.com/TheCacophonyProject/go-cptv/writer_reader_test.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/writer_reader_test.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Cacophony Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cptv
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/TheCacophonyProject/lepton3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterAndReader(t *testing.T) {
+	frame0 := makeTestFrame()
+	frame1 := makeOffsetFrame(frame0)
+	frame2 := makeOffsetFrame(frame1)
+
+	cptvBytes := new(bytes.Buffer)
+
+	w := NewWriter(cptvBytes)
+	require.NoError(t, w.WriteHeader("nz42"))
+	require.NoError(t, w.WriteFrame(frame0))
+	require.NoError(t, w.WriteFrame(frame1))
+	require.NoError(t, w.WriteFrame(frame2))
+	require.NoError(t, w.Close())
+
+	r, err := NewReader(cptvBytes)
+	require.NoError(t, err)
+	assert.Equal(t, "nz42", r.DeviceName())
+	assert.True(t, time.Since(r.Timestamp()) < time.Minute)
+
+	frameD := new(lepton3.Frame)
+	require.NoError(t, r.ReadFrame(frameD))
+	assert.Equal(t, frame0, frameD)
+	require.NoError(t, r.ReadFrame(frameD))
+	assert.Equal(t, frame1, frameD)
+	require.NoError(t, r.ReadFrame(frameD))
+	assert.Equal(t, frame2, frameD)
+
+	assert.Equal(t, io.EOF, r.ReadFrame(frameD))
+}


### PR DESCRIPTION
The Writer.WriteFrame() API no longer requires the previous frame so some minor code updates were required..