### PR TITLE
Have leptond force FFC regularly

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/TheCacophonyProject/lepton3"
   packages = ["."]
-  revision = "c979564ef5f8db3d8cff8381b4493d79841dd6bf"
+  revision = "71219abeef2193049b0e7889765694f92772e634"
 
 [[projects]]
   branch = "master"

--- a/cmd/thermal-recorder/main.go
+++ b/cmd/thermal-recorder/main.go
@@ -139,7 +139,7 @@ func handleConn(conn net.Conn, conf *Config, turret *TurretController) error {
 	totalFrames := 0
 
 	cptvRecorder := NewCPTVFileRecorder(conf)
-	defer cptvRecorder.Stop()
+	defer cptvRecorder.StopRecording()
 	var recorder recorder.Recorder = cptvRecorder
 
 	var throttledRecorder *throttle.ThrottledRecorder


### PR DESCRIPTION
This means that leptond is more in control of the FFC process (the camera automatically runs it every 5 minutes) which means it can drop the connection to thermal-recorder during recalibration removing the need for thermal-recorder to ignore the crazy values seen during FFC.