### PR TITLE
Update go-cptv dependency again

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:409fbbdb8d38399a13b7b2d2a8f57080c91ca13f1f6d4fae64741bbbb8e2c487"
+  digest = "1:b25e2936aa15bd13825b2704a18496ab80ef22b10a1cdcb693d8b1550027b426"
   name = "github.com/TheCacophonyProject/go-cptv"
   packages = ["."]
   pruneopts = ""
-  revision = "234405467a0efff0b9abb13f641cfce670a3fd1b"
+  revision = "cfce3277dd0d4c38b3ef1c1cae28cdd2c8dceaf8"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/TheCacophonyProject/go-cptv/SPECv2.md
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/SPECv2.md
@@ -71,8 +71,8 @@ After these a number of fields will exist.
 | Latitude      | 4        | 'L'   | float32 | Latitude of device location
 | Longitude     | 4        | 'O'   | float32 | Longitude of device location
 | LocTimestamp  | 8        | 'S'   | uint64  | Time at which location of device was set.  Microseconds since 1970-01-01 UTC
-| Altitude      | 4        | 'A'   | float32 | Altitude of device location
-| Precision     | 4        | 'R'   | float32 | Estimated precision of location
+| Altitude      | 4        | 'A'   | float32 | Altitude of device location in metres.
+| Accuracy      | 4        | 'U'   | float32 | Estimated accuracy of location settings in metres.
 
 ## Frames
 

--- a/vendor/github.com/TheCacophonyProject/go-cptv/cmd/createcptv/main.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/cmd/createcptv/main.go
@@ -62,7 +62,7 @@ func createCPTVFile(cptvFileName string) {
 		Longitude:    174.76667,
 		LocTimestamp: lts,
 		Altitude:     200,
-		Precision:    80.5,
+		Accuracy:     10,
 	}
 	w.WriteHeader(header)
 
@@ -101,7 +101,7 @@ func openAndDisplayCPTVFileContents(cptvFileName string) {
 	fmt.Println("\tLongitude =", r.Longitude())
 	fmt.Println("\tlocTimeStamp =", r.LocTimestamp().UTC())
 	fmt.Println("\tAltitude =", r.Altitude())
-	fmt.Println("\tPrecision =", r.Precision())
+	fmt.Println("\tAccuracy =", r.Accuracy())
 	frameCount, err := r.FrameCount()
 	fmt.Println("\tNum Frames =", frameCount)
 

--- a/vendor/github.com/TheCacophonyProject/go-cptv/const.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/const.go
@@ -33,7 +33,7 @@ const (
 	Longitude    byte = 'O'
 	LocTimestamp byte = 'S'
 	Altitude     byte = 'A'
-	Precision    byte = 'R'
+	Accuracy     byte = 'U'
 
 	// Frame field keys
 	TimeOn      byte = 't'

--- a/vendor/github.com/TheCacophonyProject/go-cptv/reader.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/reader.go
@@ -110,10 +110,10 @@ func (r *Reader) Altitude() float32 {
 	return alt
 }
 
-// Precision returns the estimated precision of the location of the device
+// Accuracy returns the estimated accuracy of the location setting of the device
 // when this CPTV file was recorded. Returns 0 if the field is not included.
-func (r *Reader) Precision() float32 {
-	pre, _ := r.header.Float32(Precision)
+func (r *Reader) Accuracy() float32 {
+	pre, _ := r.header.Float32(Accuracy)
 	return pre
 }
 

--- a/vendor/github.com/TheCacophonyProject/go-cptv/writer.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/writer.go
@@ -46,7 +46,7 @@ type Header struct {
 	Longitude    float32
 	LocTimestamp time.Time
 	Altitude     float32
-	Precision    float32
+	Accuracy     float32
 }
 
 // WriteHeader writes a CPTV file header
@@ -90,8 +90,8 @@ func (w *Writer) WriteHeader(header Header) error {
 	if header.Altitude >= 0.0 {
 		fields.Float32(Altitude, header.Altitude)
 	}
-	if header.Precision != 0.0 {
-		fields.Float32(Precision, header.Precision)
+	if header.Accuracy != 0.0 {
+		fields.Float32(Accuracy, header.Accuracy)
 	}
 
 	return w.bldr.WriteHeader(fields)

--- a/vendor/github.com/TheCacophonyProject/go-cptv/writer_reader_test.go
+++ b/vendor/github.com/TheCacophonyProject/go-cptv/writer_reader_test.go
@@ -43,7 +43,7 @@ func TestRoundTripHeaderDefaults(t *testing.T) {
 	assert.Equal(t, float32(0.0), r.Longitude())
 	assert.True(t, r.LocTimestamp().IsZero()) // time.Time zero value was used
 	assert.Equal(t, float32(0.0), r.Altitude())
-	assert.Equal(t, float32(0.0), r.Precision())
+	assert.Equal(t, float32(0.0), r.Accuracy())
 
 }
 
@@ -62,7 +62,7 @@ func TestRoundTripHeader(t *testing.T) {
 		Longitude:    174.76667,
 		LocTimestamp: lts,
 		Altitude:     200,
-		Precision:    80.5,
+		Accuracy:     10,
 	}
 	require.NoError(t, w.WriteHeader(header))
 	require.NoError(t, w.Close())
@@ -77,7 +77,7 @@ func TestRoundTripHeader(t *testing.T) {
 	assert.Equal(t, float32(174.76667), r.Longitude())
 	assert.Equal(t, lts, r.LocTimestamp().UTC())
 	assert.Equal(t, float32(200), r.Altitude())
-	assert.Equal(t, float32(80.5), r.Precision())
+	assert.Equal(t, float32(10), r.Accuracy())
 
 }
 


### PR DESCRIPTION
Some fields have been renamed. This change is required to allow the build to pass for #84.