### PR TITLE
 motion: Fix logging in MotionProcessor

### DIFF
--- a/loglimiter/loglimiter.go
+++ b/loglimiter/loglimiter.go
@@ -1,0 +1,55 @@
+// thermal-recorder - record thermal video footage of warm moving objects
+// Copyright (C) 2019, The Cacophony Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package loglimiter
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+// New returns a new LogLimiter with the configured minimum log interval.
+func New(interval time.Duration) *LogLimiter {
+	return &LogLimiter{
+		interval: interval,
+		nowFunc:  time.Now,
+	}
+}
+
+// LogLimiter will suppress log messages if the same log message is
+// seen within some time interval.
+type LogLimiter struct {
+	interval      time.Duration
+	nowFunc       func() time.Time
+	previousEntry string
+	previousTime  time.Time
+}
+
+func (limiter *LogLimiter) Printf(format string, v ...interface{}) {
+	limiter.Print(fmt.Sprintf(format, v...))
+}
+
+func (limiter *LogLimiter) Print(s string) {
+	now := limiter.nowFunc()
+	if now.Sub(limiter.previousTime) < limiter.interval && s == limiter.previousEntry {
+		return
+	}
+
+	log.Print(s)
+	limiter.previousTime = now
+	limiter.previousEntry = s
+}

--- a/loglimiter/loglimiter_test.go
+++ b/loglimiter/loglimiter_test.go
@@ -1,0 +1,127 @@
+// thermal-recorder - record thermal video footage of warm moving objects
+// Copyright (C) 2019, The Cacophony Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package loglimiter
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrint(t *testing.T) {
+	logs, reset := captureLogs()
+	defer reset()
+
+	limiter := New(time.Minute)
+	limiter.Print("hello")
+	limiter.Print("world")
+
+	assert.Equal(t, "hello\nworld\n", logs.String())
+}
+
+func TestPrintf(t *testing.T) {
+	logs, reset := captureLogs()
+	defer reset()
+
+	limiter := New(time.Minute)
+	limiter.Printf("hello: %d", 42)
+	limiter.Printf("world: %q", "hi")
+
+	assert.Equal(t, "hello: 42\nworld: \"hi\"\n", logs.String())
+}
+
+func TestLimitPrint(t *testing.T) {
+	logs, reset := captureLogs()
+	defer reset()
+
+	now := time.Now()
+
+	limiter := New(2 * time.Second)
+	limiter.nowFunc = func() time.Time { return now }
+
+	limiter.Print("hello")
+	assert.Equal(t, "hello\n", logs.String())
+
+	// Advance time but still within the window.
+	now = now.Add(time.Second)
+	limiter.Print("hello")
+	assert.Equal(t, "hello\n", logs.String())
+
+	// Now go past the window; see that second line is logged.
+	now = now.Add(time.Second)
+	limiter.Print("hello")
+	assert.Equal(t, "hello\nhello\n", logs.String())
+
+	// Log something else and see that this is let through.
+	limiter.Print("world")
+	assert.Equal(t, "hello\nhello\nworld\n", logs.String())
+
+	// Log again, and see it be suppressed..
+	limiter.Print("world")
+	assert.Equal(t, "hello\nhello\nworld\n", logs.String())
+}
+
+func TestLimitPrintf(t *testing.T) {
+	logs, reset := captureLogs()
+	defer reset()
+
+	now := time.Now()
+
+	limiter := New(2 * time.Second)
+	limiter.nowFunc = func() time.Time { return now }
+
+	limiter.Printf("hello")
+	assert.Equal(t, "hello\n", logs.String())
+
+	// Advance time but still within the window.
+	now = now.Add(time.Second)
+	limiter.Printf("hello")
+	assert.Equal(t, "hello\n", logs.String())
+
+	// Now go past the window; see that second line is logged.
+	now = now.Add(time.Second)
+	limiter.Printf("hello")
+	assert.Equal(t, "hello\nhello\n", logs.String())
+}
+
+func TestMixed(t *testing.T) {
+	logs, reset := captureLogs()
+	defer reset()
+
+	// Mixing Print and Printf doesn't matter if the resulting string is the same.
+	limiter := New(time.Minute)
+	limiter.Print("hello")
+	limiter.Printf("hello")
+	assert.Equal(t, "hello\n", logs.String())
+}
+
+func captureLogs() (*bytes.Buffer, func()) {
+	flags := log.Flags()
+	log.SetFlags(0)
+
+	logs := new(bytes.Buffer)
+	log.SetOutput(logs)
+
+	return logs, func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(flags)
+	}
+}

--- a/motion/motionprocessor.go
+++ b/motion/motionprocessor.go
@@ -84,10 +84,10 @@ type RecordingListener interface {
 func (mp *MotionProcessor) Process(rawFrame *lepton3.RawFrame) {
 	frame := mp.frameLoop.Current()
 	rawFrame.ToFrame(frame)
-	mp.internalProcess(frame)
+	mp.process(frame)
 }
 
-func (mp *MotionProcessor) internalProcess(frame *lepton3.Frame) {
+func (mp *MotionProcessor) process(frame *lepton3.Frame) {
 	mp.totalFrames++
 	if mp.motionDetector.Detect(frame) {
 		if mp.listener != nil {
@@ -131,11 +131,9 @@ func (mp *MotionProcessor) internalProcess(frame *lepton3.Frame) {
 }
 
 func (mp *MotionProcessor) ProcessFrame(srcFrame *lepton3.Frame) {
-
 	frame := mp.frameLoop.Current()
 	frame.Copy(srcFrame)
-
-	mp.internalProcess(frame)
+	mp.process(frame)
 }
 
 func (mp *MotionProcessor) GetRecentFrame(frame *lepton3.Frame) *lepton3.Frame {
@@ -166,9 +164,8 @@ func (mp *MotionProcessor) canStartWriting() error {
 	mp.setSunriseSunsetWindow()
 	if !mp.window.Active() {
 		return errors.New("motion detected but outside of recording window")
-	} else {
-		return mp.recorder.CheckCanRecord()
 	}
+	return mp.recorder.CheckCanRecord()
 }
 
 func (mp *MotionProcessor) occasionallyWriteError(task string, err error) {
@@ -180,10 +177,7 @@ func (mp *MotionProcessor) occasionallyWriteError(task string, err error) {
 }
 
 func (mp *MotionProcessor) startRecording() error {
-
-	var err error
-
-	if err = mp.recorder.StartRecording(); err != nil {
+	if err := mp.recorder.StartRecording(); err != nil {
 		return err
 	}
 
@@ -192,8 +186,7 @@ func (mp *MotionProcessor) startRecording() error {
 		mp.listener.RecordingStarted()
 	}
 
-	err = mp.recordPreTriggerFrames()
-	return err
+	return mp.recordPreTriggerFrames()
 }
 
 func (mp *MotionProcessor) stopRecording() error {
@@ -213,13 +206,6 @@ func (mp *MotionProcessor) stopRecording() error {
 	return err
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (mp *MotionProcessor) recordPreTriggerFrames() error {
 	frames := mp.frameLoop.GetHistory()
 	var frame *lepton3.Frame
@@ -235,4 +221,11 @@ func (mp *MotionProcessor) recordPreTriggerFrames() error {
 	}
 
 	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
The logging about motion events outside of the recording window were broken (commented out code)

Extracted log limiting to a new loglimiter.LogLimiter type. Repeated motion processor logs are now restricted to a minimum interval of 1 minute.

Also made some small code cleanups.