### PR TITLE
Add new motion detection debugging feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.10.x"
   - "1.11.x"
+  - "1.12.x"
 
 script:
   - go vet ./... && go test ./...
@@ -14,4 +14,4 @@ deploy:
   script: curl -sL https://git.io/goreleaser | bash
   on:
     tags: true
-    go: "1.11.x"
+    go: "1.12.x"

--- a/motion/debugtracker.go
+++ b/motion/debugtracker.go
@@ -1,0 +1,127 @@
+// thermal-recorder - record thermal video footage of warm moving objects
+//  Copyright (C) 2018, The Cacophony Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package motion
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+type debugTracker struct {
+	values map[string]*value
+}
+
+func newDebugTracker() *debugTracker {
+	return &debugTracker{
+		values: make(map[string]*value),
+	}
+}
+
+func (d *debugTracker) update(name string, x int) {
+	if d == nil {
+		return
+	}
+	value := d.values[name]
+	if value == nil {
+		value = newValue()
+		d.values[name] = value
+	}
+	value.update(x)
+}
+
+func (d *debugTracker) reset() {
+	if d == nil {
+		return
+	}
+	for _, value := range d.values {
+		value.reset()
+	}
+}
+
+// string takes a format string and generates a string representation
+// of the tracked values.  A format string looks like "foo:min
+// bar:all" where foo and bar are field names and min and all are
+// output formats.
+// Available formats are "n", "min", "max", "avg", "all".
+func (d *debugTracker) string(format string) string {
+	if d == nil {
+		return ""
+	}
+	var out []string
+	for _, field := range strings.Split(format, " ") {
+		parts := strings.Split(field, ":")
+		if len(parts) != 2 {
+			continue
+		}
+		name, style := parts[0], parts[1]
+		value := d.values[name]
+		if value != nil {
+			out = append(out, fmt.Sprintf("%s: %s", name, value.format(style)))
+		}
+	}
+	return strings.Join(out, "; ")
+}
+
+func newValue() *value {
+	v := new(value)
+	v.reset()
+	return v
+}
+
+type value struct {
+	n   int
+	min int
+	max int
+	avg float64
+}
+
+func (v *value) reset() {
+	v.n = 0
+	v.max = math.MinInt32
+	v.min = math.MaxInt32
+	v.avg = 0
+}
+
+func (v *value) update(x int) {
+	v.n++
+	if x > v.max {
+		v.max = x
+	}
+	if x < v.min {
+		v.min = x
+	}
+	// Cumulative moving average
+	v.avg = v.avg + ((float64(x) - v.avg) / float64(v.n))
+}
+
+func (v *value) format(style string) string {
+	switch style {
+	case "n":
+		return fmt.Sprint(v.n)
+	case "min":
+		return fmt.Sprint(v.min) + "(min)"
+	case "max":
+		return fmt.Sprint(v.max) + "(max)"
+	case "avg":
+		return fmt.Sprintf("%.2f(avg)", v.avg)
+	case "all":
+		return fmt.Sprintf("%d -> %d (avg: %.2f)", v.min, v.max, v.avg)
+	default:
+		return "???"
+	}
+}

--- a/motion/motion.go
+++ b/motion/motion.go
@@ -34,12 +34,12 @@ func NewMotionDetector(args MotionConfig) *motionDetector {
 	d.flooredFrames = *NewFrameLoop(args.FrameCompareGap + 1)
 	d.diffFrames = *NewFrameLoop(2)
 	d.useOneDiff = args.UseOneDiffOnly
-	d.framesGap = uint64(args.FrameCompareGap)
 	d.deltaThresh = args.DeltaThresh
 	d.countThresh = args.CountThresh
 	d.tempThresh = args.TempThresh
 	d.verbose = args.Verbose
 	d.warmerOnly = args.WarmerOnly
+
 	d.start = args.EdgePixels
 	d.columnStop = lepton3.FrameCols - args.EdgePixels
 	d.rowStop = lepton3.FrameRows - args.EdgePixels
@@ -55,7 +55,6 @@ type motionDetector struct {
 	tempThresh    uint16
 	deltaThresh   uint16
 	countThresh   int
-	framesGap     uint64
 	verbose       bool
 	warmerOnly    bool
 	start         int
@@ -69,8 +68,8 @@ func (d *motionDetector) Detect(frame *lepton3.Frame) bool {
 }
 
 func (d *motionDetector) pixelsChanged(frame *lepton3.Frame) (bool, int) {
-	processedFrame := d.flooredFrames.Current()
-	d.setFloor(frame, processedFrame)
+	flooredFrame := d.flooredFrames.Current()
+	d.setFloor(frame, flooredFrame)
 
 	// we will compare with the oldest saved frame.
 	compareFrame := d.flooredFrames.Oldest()
@@ -78,9 +77,9 @@ func (d *motionDetector) pixelsChanged(frame *lepton3.Frame) (bool, int) {
 
 	diffFrame := d.diffFrames.Current()
 	if d.warmerOnly {
-		d.warmerDiffFrames(processedFrame, compareFrame, diffFrame)
+		d.warmerDiffFrames(flooredFrame, compareFrame, diffFrame)
 	} else {
-		d.absDiffFrames(processedFrame, compareFrame, diffFrame)
+		d.absDiffFrames(flooredFrame, compareFrame, diffFrame)
 	}
 	prevDiffFrame := d.diffFrames.Move()
 


### PR DESCRIPTION
The `motion.verbose` setting now causes various motion detection values to be tracked. These are emitted to the logs every 5s (this interval was chosen to provide enough granularity while not causing too much disk I/O or consuming too much disk space).

The log likes look like: 
```
motion:: temp: 3260 -> 3469 (avg: 3368.63); ftemp: 3260 -> 3469 (avg: 3368.63); diff: 24(max); delta: 0(max); ffc: 0
```

Also:
* Reverted time override in CPTV playback tester that was breaking FFC detection when playing back modern CPTV files
* minor code cleanups
