### PR TITLE
Updates for newer versions of Goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,8 @@ release:
   name_template: '{{.Tag}}'
 
 builds:
-- binary: thermal-recorder
+- id: thermal-recorder
+  binary: thermal-recorder
   main: ./cmd/thermal-recorder
   goos:
     - linux
@@ -17,7 +18,8 @@ builds:
   goarm:
     - "7"
   ldflags: -s -w -X main.version={{.Version}}
-- binary: leptond
+- id: leptond
+  binary: leptond
   main: ./cmd/leptond
   goos:
     - linux
@@ -27,7 +29,8 @@ builds:
     - "7"
   ldflags: -s -w -X main.version={{.Version}}
 
-nfpm:
+nfpms:
+-
   vendor: The Cacophony Project
   homepage: http://cacophony.org.nz/
   maintainer: Menno Finlay-Smits <menno@cacophony.org.nz>

--- a/README.md
+++ b/README.md
@@ -7,14 +7,9 @@ project's own CPTV format.
 
 ## Releases
 
-Releases are built using TravisCI. To create a release:
+Releases are built using TravisCI. To create a release visit the
+[repository on Github](https://github.com/TheCacophonyProject/thermal-recorder/releases)
+and then follow our [general instructions](https://docs.cacophony.org.nz/home/creating-releases)
+for creating a release.
 
-* Tag the release with an annotated tag. For example:
-  `git tag -a "v1.4" -m "1.4 release"`
-* Push the tag to Github: `git push origin v1.4`
-* TravisCI will see the pushed tag, run the tests, create a release
-  package and create a
-  [Github Release](https://github.com/TheCacophonyProject/thermal-recorder/releases).
-
-For more about the mechanics of how releases work, see `travis.yml`
-and `.goreleaser.yml`.
+For more about the mechanics of how releases work, see `.travis.yml` and `.goreleaser.yml`.


### PR DESCRIPTION
- Each build section requires a unique id
- Move from nfpm to nfpms (https://goreleaser.com/deprecations/#nfpm)