### PR TITLE
Clear buffer

### DIFF
--- a/cmd/leptond/main.go
+++ b/cmd/leptond/main.go
@@ -47,7 +47,7 @@ const (
 	framesPerSdNotify = 5 * framesHz
 
 	telemetryBytes = 160 * 4 //this should be made public in lepton3
-	clearBuffer = "clear"
+	clearBuffer    = "clear"
 )
 
 var version = "<not set>"
@@ -155,6 +155,7 @@ func runMain() error {
 		if err != nil {
 			return err
 		}
+		log.Print("Clearing Buffer")
 		conn.Write([]byte(clearBuffer))
 	}
 }
@@ -219,13 +220,11 @@ func runCamera(conf *Config, camera *lepton3.Lepton3, conn *net.UnixConn) error 
 	conn.SetWriteBuffer(camera.ResX() * camera.ResY() * 2 * 20)
 	log.Print("reading frames")
 	frame := lepton3.NewRawFrame()
-
 	notifyCount := 0
 	for {
 		if err := camera.NextFrame(frame); err != nil {
 			return &nextFrameErr{err}
 		}
-
 		if firstPixel(frame) == 0 {
 			event := eventclient.Event{
 				Timestamp: time.Now(),

--- a/cmd/leptond/main.go
+++ b/cmd/leptond/main.go
@@ -47,6 +47,7 @@ const (
 	framesPerSdNotify = 5 * framesHz
 
 	telemetryBytes = 160 * 4 //this should be made public in lepton3
+	clearBuffer = "clear"
 )
 
 var version = "<not set>"
@@ -154,6 +155,7 @@ func runMain() error {
 		if err != nil {
 			return err
 		}
+		conn.Write([]byte(clearBuffer))
 	}
 }
 

--- a/cmd/thermal-recorder/main.go
+++ b/cmd/thermal-recorder/main.go
@@ -178,30 +178,22 @@ func handleConn(conn net.Conn, conf *Config) error {
 	frameLogInterval *= header.FPS()
 	rawFrame := make([]byte, header.FrameSize())
 	for {
-		_, err := io.ReadFull(reader, rawFrame[:8])
+		_, err := io.ReadFull(reader, rawFrame[:5])
 		if err != nil {
 			return err
 		}
-		message := string(rawFrame[:8])
-		if message == clearBuffer{
+		message := string(rawFrame[:5])
+		if message == clearBuffer {
 			log.Print("clearing motion buffer")
-			processor.StopRecording()
-			processor = motion.NewMotionProcessor(
-				parseFrame,
-				&conf.Motion,
-				&conf.Recorder,
-				&conf.Location,
-				nil,
-				recorder,
-				header,
-			)
+			processor.Reset(header)
 			continue
 		}
 
-		_, err = io.ReadFull(reader, rawFrame[8:])
+		_, err = io.ReadFull(reader, rawFrame[5:])
 		if err != nil {
 			return err
 		}
+		message = string(rawFrame[:5])
 		totalFrames++
 
 		if totalFrames%frameLogIntervalFirstMin == 0 &&

--- a/motion/frameloop.go
+++ b/motion/frameloop.go
@@ -52,6 +52,12 @@ type FrameLoop struct {
 	mu            sync.Mutex
 }
 
+func (fl *FrameLoop) Reset() {
+	fl.currentIndex = 0
+	fl.oldest = 0
+	fl.bufferFull = false
+
+}
 func (fl *FrameLoop) nextIndexAfter(index int) int {
 	return (index + 1) % fl.size
 }

--- a/motion/motion.go
+++ b/motion/motion.go
@@ -92,6 +92,13 @@ type motionDetector struct {
 	framesHz         int
 }
 
+func (d *motionDetector) Reset(camera cptvframe.CameraSpec) {
+	d.backgroundFrames = 0
+	d.count = 0
+	d.flooredFrames.Reset()
+	d.diffFrames.Reset()
+}
+
 func (d *motionDetector) calculateThreshold(backAverage float64) {
 	if d.tempThreshMin != 0 {
 		d.tempThresh = uint16(math.Max(backAverage, float64(d.tempThreshMin)))

--- a/motion/motionprocessor.go
+++ b/motion/motionprocessor.go
@@ -87,13 +87,14 @@ type RecordingListener interface {
 }
 
 func (mp *MotionProcessor) Process(rawFrame []byte) error {
-	frame := mp.frameLoop.Current()
-	if err := mp.parseFrame(rawFrame, frame); err != nil {
-		return err
-	}
-	mp.process(frame)
-	return nil
+       frame := mp.frameLoop.Current()
+       if err := mp.parseFrame(rawFrame, frame); err != nil {
+               return err
+       }
+       mp.process(frame)
+       return nil
 }
+
 
 func (mp *MotionProcessor) process(frame *cptvframe.Frame) {
 	if mp.motionDetector.Detect(frame) {
@@ -130,7 +131,7 @@ func (mp *MotionProcessor) process(frame *cptvframe.Frame) {
 	mp.frameLoop.Move()
 
 	if mp.isRecording && mp.framesWritten >= mp.writeUntil {
-		err := mp.stopRecording()
+		err := mp.StopRecording()
 		if err != nil {
 			mp.log.Printf("Failed to stop recording CPTV file %v", err)
 		}
@@ -168,7 +169,10 @@ func (mp *MotionProcessor) startRecording() error {
 	return mp.recordPreTriggerFrames()
 }
 
-func (mp *MotionProcessor) stopRecording() error {
+func (mp *MotionProcessor) StopRecording() error {
+	if !mp.isRecording {
+		return nil
+	}
 	if mp.listener != nil {
 		mp.listener.RecordingEnded()
 	}


### PR DESCRIPTION
When we get a frame error or a zero pixel event, clear the buffer of frames to detect motion. As camera values will change after the power has been cycled

Have tested on my PI ( with 1 minute fake zero pixel events) .
Pre clearing https://browse-test.cacophony.org.nz/recording/176981?tagMode=any
Post clearing https://browse-test.cacophony.org.nz/recording/176982?tagMode=any