### PR TITLE
keep existing background after ffc events

### DIFF
--- a/motion/motion.go
+++ b/motion/motion.go
@@ -114,7 +114,7 @@ func (d *motionDetector) Detect(frame *cptvframe.Frame) bool {
 	prevFFC := d.affectedByFCC
 	d.affectedByFCC = isAffectedByFFC(frame)
 	if d.dynamicThresh && !d.affectedByFCC {
-		backAverage, changed := d.updateBackground(frame, prevFFC)
+		backAverage, changed := d.updateBackground(frame)
 		if changed && d.backgroundFrames > d.previewFrames {
 			d.calculateThreshold(backAverage)
 		}
@@ -250,7 +250,7 @@ func (d *motionDetector) warmerDiffFrames(a, b, out *cptvframe.Frame) *cptvframe
 	return out
 }
 
-func (d *motionDetector) updateBackground(new_frame *cptvframe.Frame, prevFFC bool) (float64, bool) {
+func (d *motionDetector) updateBackground(new_frame *cptvframe.Frame) (float64, bool) {
 	d.backgroundFrames++
 	if d.backgroundFrames == 1 {
 		for y := d.start; y < d.rowStop; y++ {
@@ -273,7 +273,7 @@ func (d *motionDetector) updateBackground(new_frame *cptvframe.Frame, prevFFC bo
 	for y := d.start; y < d.rowStop; y++ {
 		for x := d.start; x < d.columnStop; x++ {
 			weight := d.backgroundWeight[y][x]
-			if prevFFC || (float32(new_frame.Pix[y][x])-weight) < float32(d.background.Pix[y][x]) {
+			if (float32(new_frame.Pix[y][x]) - weight) < float32(d.background.Pix[y][x]) {
 				d.background.Pix[y][x] = new_frame.Pix[y][x]
 				d.backgroundWeight[y][x] = 0
 				changed = true

--- a/motion/motion_test.go
+++ b/motion/motion_test.go
@@ -147,7 +147,7 @@ func TestBackgroundEdges(t *testing.T) {
 	frame := g.setupFrame(backgroundValue)
 	SetFrameEdge(frame, config.EdgePixels, edgeValue)
 
-	detector.updateBackground(frame, false)
+	detector.updateBackground(frame)
 	for y := range frame.Pix {
 		for x := 0; x < len(frame.Pix[y]); x++ {
 			assert.Equal(t, detector.background.Pix[y][x], uint16(backgroundValue))
@@ -157,7 +157,7 @@ func TestBackgroundEdges(t *testing.T) {
 	backgroundValue = 2000
 	frame = g.setupFrame(backgroundValue)
 	SetFrameEdge(frame, config.EdgePixels, edgeValue)
-	detector.updateBackground(frame, false)
+	detector.updateBackground(frame)
 
 	for y := range frame.Pix {
 		for x := 0; x < len(frame.Pix[y]); x++ {


### PR DESCRIPTION
Currently the background is updated always after an ffc event. This is causing some problems in recodings such as:
https://browse.cacophony.org.nz/recording/869743?device=1503
where an animal is in the frame during an ffc event. 

The danger with not resetting the background is often pixels are a lot warmer after ffc events, so it may increase false triggers by comparing the current frame to the backgorund pre FFC.